### PR TITLE
Server options as functions for passing custom URIs and AllowOrigins easily

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,4 +1,4 @@
-package main
+package auth
 
 import (
 	"encoding/json"

--- a/app/app.go
+++ b/app/app.go
@@ -17,7 +17,13 @@ func init() {
 	auth = fb.Auth()
 
 	// auth server comes with CORS included
-	http.Handle("/", auth.Server(customClaims))
+	http.Handle("/", auth.Server(customClaims,
+		// Custom AllowedOrigins
+		firebase.ServerAllowedOrigins([]string{"*"}),
+		// Custom URI for verifyHandler
+		firebase.ServerVerifyURI("/customVerify"),
+		// Custom URI for generateHandler
+		firebase.ServerGenerateURI("/customGenerate")))
 
 	// but we need to add it for the API endpoint
 	c := cors.New(cors.Options{

--- a/app/app.go
+++ b/app/app.go
@@ -21,9 +21,9 @@ func init() {
 		// Custom AllowedOrigins
 		firebase.ServerAllowedOrigins([]string{"*"}),
 		// Custom URI for verifyHandler
-		firebase.ServerVerifyURI("/customVerify"),
+		firebase.ServerVerifyURI("/verify"),
 		// Custom URI for generateHandler
-		firebase.ServerGenerateURI("/customGenerate")))
+		firebase.ServerGenerateURI("/token")))
 
 	// but we need to add it for the API endpoint
 	c := cors.New(cors.Options{


### PR DESCRIPTION
I'd like to thank you for this package. It is really hard to find an existing implementation that works with App Engine,

I saw that you are using hardcoded `/verify` and `/token` URIs for handlers, and you had a TODO tag for passing custom `AllowOrigins`. Since I needed custom URIs for handlers and also custom AllowOrigins, I made a small modification in server.go to add these.

I added an optional `options` parameter to `auth.Server()` method. `options` are list of functions that you can pass to set options:
- `ServerGenerateURI` to pass a custom URI for s.generateHandler
- `ServerVerifyURI` to pass a custom URI for s.verifyHandler
- `ServerAllowedOrigins` to pass a custom list of origins into AllowedOrigins

In case any these are not passed, defaults are set as they were in original implementation.

If no options passed, `auth.Server()` will run as it was, so any existing implementation won't be broken.

I also modified sample app.go to show these options used:
`
http.Handle("/", auth.Server(customClaims,
	// Custom AllowedOrigins
	firebase.ServerAllowedOrigins([]string{"*"}),
	// Custom URI for verifyHandler
	firebase.ServerVerifyURI("/customVerify"),
	// Custom URI for generateHandler
	firebase.ServerGenerateURI("/customGenerate")))
`

I hope you find this merge request useful and accept it.