### PR TITLE
Custom ServeMux usage

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -1,4 +1,4 @@
-package firebase // import "github.com/captaincodeman/go-firebase"
+package firebase
 
 import (
 	"fmt"

--- a/server.go
+++ b/server.go
@@ -17,8 +17,16 @@ type (
 		generateURI    string
 		verifyURI      string
 		allowedOrigins []string
+		serveMux       *http.ServeMux
 	}
 )
+
+// ServerServeMux Uses the existing ServeMux
+func ServerServeMux(m *http.ServeMux) func(*Server) {
+	return func(s *Server) {
+		s.serveMux = m
+	}
+}
 
 // ServerGenerateURI Sets URI for the token generation
 func ServerGenerateURI(uri string) func(*Server) {
@@ -66,6 +74,9 @@ func (a *Auth) Server(claimsFn CreateClaimsFunc, options ...func(*Server)) http.
 
 	// endpoints to issue and verify tokens
 	m := http.NewServeMux()
+	if s.serveMux != nil {
+		m = s.serveMux
+	}
 
 	m.HandleFunc(s.generateURI, s.generateHandler)
 	m.HandleFunc(s.verifyURI, s.verifyHandler)
@@ -137,3 +148,4 @@ func (s *Server) verifyHandler(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
 	enc.Encode(token.Claims())
 }
+


### PR DESCRIPTION
`auth.Server()` method is creating a new `ServeMux` and setting the handlers for generate and verify handlers. This is useful when you are using `http.Handler` or `http.HadleFunc` with default `ServeMux`. However, this is making `auth.Server()` unusable with something like `gorilla/mux`.

This pull request allows user to pass the default or any custom `ServeMux` into `auth.Server()`, so it can be used along with `gorilla/mux` or any similar packages.

Example:
```
serveMux := http.DefaultServeMux

router := mux.NewRouter()
router.Handle("/auth", auth.Server(customClaims,
	firebase.ServerServeMux(serveMux),
	firebase.ServerGenerateURI("/auth/token"),
	firebase.ServerVerifyURI("/auth/verify")))

apiRouter := router.PathPrefix("/api").Subrouter()

// but we need to add it for the API endpoint
c := cors.New(cors.Options{
	AllowedOrigins: []string{"*"},
	AllowedHeaders: []string{"Authorization"},
})

// API Handlers
apiRouter.Handle("/account/create", c.Handler(auth.AnyRole(http.HandlerFunc(createAccount),"user")))

http.Handle("/", router)
```

`auth.Server()` creates a new `ServeMux` if nothing is passed.